### PR TITLE
Enable usage for non-root users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,11 @@ ENV VERSION master
 WORKDIR /opt
 
 RUN cd /opt \
-	&& git clone -b ${VERSION} --single-branch git://git.openstack.org/openstack-infra/jenkins-job-builder \
+	&& git clone -b ${VERSION} --single-branch https://opendev.org/jjb/jenkins-job-builder.git \
 	&& cd /opt/jenkins-job-builder \
 	&& pip install -r requirements.txt \
 	&& python setup.py install \
+	&& mkdir /.cache && chmod 777 /.cache \
 	&& rm -R /opt/jenkins-job-builder
 
 ENTRYPOINT ["/usr/local/bin/jenkins-jobs"]


### PR DESCRIPTION
Master branch from `https://opendev.org/jjb/jenkins-job-builder.git` uses ssl verification which can cause

```
requests.exceptions.SSLError: HTTPSConnectionPool(host='fuse-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com', port=443): Max retries exceeded with url: /crumbIssuer/api/json (Caused by SSLError(SSLError(1, u'[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:727)'),))
```

This can be easily fixed by adding `-e PYTHONHTTPSVERIFY=0` flag to your docker command.